### PR TITLE
Remove allowBackup attribute from AndroidManifest

### DIFF
--- a/tooltips/src/main/AndroidManifest.xml
+++ b/tooltips/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.tomergoldst.tooltips">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
 


### PR DESCRIPTION
I don't think this should be set in the library. Is there a reason it is there?
Including android:allowBackup="true" means it is a hassle to override this to false in my app and will cause build failures.